### PR TITLE
Userの削除をオーナーと自身に制限、Teamの編集はオーナーのみに付与

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,9 @@ class User < ApplicationRecord
   def self.generate_password
     SecureRandom.hex(10)
   end
+
+  def owner?(team)
+    self.id == team.owner_id
+  end
+
 end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user.owner?(@team) %>
+              <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>   
           </div>
 
           <div class="col-md-8">
@@ -41,7 +43,9 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if current_user.owner?(@team) || current_user.id == assign.user_id  %>
+                        <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>


### PR DESCRIPTION
#64の以下の機能を実装

1. Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること

2. TeamのeditはTeamのリーダー（オーナー）のみができるようにすること